### PR TITLE
feat(algo_models)!: use [u8; n] and Vec<u8> for byte fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,6 @@ dependencies = [
  "rmp-serde",
  "rmpv",
  "serde",
- "serde_bytes",
  "serde_json",
  "serde_with",
  "thiserror 2.0.7",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,6 +37,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "serde_with",
  "thiserror 2.0.7",
 ]
 
@@ -351,6 +352,7 @@ dependencies = [
  "iana-time-zone",
  "js-sys",
  "num-traits",
+ "serde",
  "wasm-bindgen",
  "windows-targets 0.52.6",
 ]
@@ -486,6 +488,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "deflate64"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -498,6 +535,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -632,6 +670,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,6 +759,12 @@ dependencies = [
  "plain",
  "scroll",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -910,6 +960,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,12 +988,24 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.2",
+ "serde",
 ]
 
 [[package]]
@@ -1516,6 +1584,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.7.0",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1711,10 +1809,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -1722,6 +1822,16 @@ name = "time-core"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"
@@ -1781,7 +1891,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap",
+ "indexmap 2.7.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -1794,7 +1904,7 @@ version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap",
+ "indexmap 2.7.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2543,7 +2653,7 @@ dependencies = [
  "displaydoc",
  "flate2",
  "hmac",
- "indexmap",
+ "indexmap 2.7.0",
  "lzma-rs",
  "memchr",
  "pbkdf2",

--- a/crates/algo_models/Cargo.toml
+++ b/crates/algo_models/Cargo.toml
@@ -12,4 +12,5 @@ rmpv = { version = "1.3.0", features = ["with-serde"] }
 serde = { version = "1.0.216", features = ["derive"] }
 serde_bytes = "0.11.15"
 serde_json = "1.0.133"
+serde_with = "3.11.0"
 thiserror = "2.0.7"

--- a/crates/algo_models/Cargo.toml
+++ b/crates/algo_models/Cargo.toml
@@ -10,7 +10,6 @@ crate-type = ["cdylib", "rlib"]
 rmp-serde = "1.3.0"
 rmpv = { version = "1.3.0", features = ["with-serde"] }
 serde = { version = "1.0.216", features = ["derive"] }
-serde_bytes = "0.11.15"
 serde_json = "1.0.133"
 serde_with = "3.11.0"
 thiserror = "2.0.7"

--- a/crates/algo_models/src/lib.rs
+++ b/crates/algo_models/src/lib.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 use std::collections::BTreeMap;
 use thiserror::Error;
 
@@ -116,6 +117,7 @@ pub enum TransactionType {
 type Byte32 = serde_bytes::ByteBuf;
 type Pubkey = Byte32;
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct TransactionHeader {
     #[serde(rename = "type")]
@@ -133,31 +135,26 @@ pub struct TransactionHeader {
     pub last_valid: u64,
 
     #[serde(rename = "gh")]
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub genesis_hash: Option<Byte32>,
 
     #[serde(rename = "gen")]
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub genesis_id: Option<String>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub note: Option<serde_bytes::ByteBuf>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "rekey")]
     pub rekey_to: Option<Pubkey>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "lx")]
     pub lease: Option<Byte32>,
 
-    #[serde(skip_serializing_if = "Option::is_none")]
     #[serde(rename = "grp")]
     pub group: Option<Byte32>,
 }
 
 impl AlgorandMsgpack for TransactionHeader {}
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct PayTransactionFields {
     #[serde(flatten)]
@@ -170,12 +167,12 @@ pub struct PayTransactionFields {
     pub amount: u64,
 
     #[serde(rename = "close")]
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub close_remainder_to: Option<Pubkey>,
 }
 
 impl AlgorandMsgpack for PayTransactionFields {}
 
+#[skip_serializing_none]
 #[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
 pub struct AssetTransferTransactionFields {
     #[serde(flatten)]
@@ -191,11 +188,9 @@ pub struct AssetTransferTransactionFields {
     pub receiver: Pubkey,
 
     #[serde(rename = "asnd")]
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub asset_sender: Option<Pubkey>,
 
     #[serde(rename = "aclose")]
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub close_remainder_to: Option<Pubkey>,
 }
 

--- a/crates/algo_models_ffi/src/lib.rs
+++ b/crates/algo_models_ffi/src/lib.rs
@@ -196,79 +196,116 @@ impl From<TransactionType> for algo_models::TransactionType {
 
 // TODO: Impl TryFrom instead of using expect
 
-impl From<TransactionHeader> for algo_models::TransactionHeader {
-    fn from(tx: TransactionHeader) -> Self {
-        Self {
+impl TryFrom<TransactionHeader> for algo_models::TransactionHeader {
+    type Error = MsgPackError;
+
+    fn try_from(tx: TransactionHeader) -> Result<Self, MsgPackError> {
+        Ok(Self {
             transaction_type: tx.transaction_type.into(),
-            sender: tx
-                .sender
-                .to_vec()
-                .try_into()
-                .expect("sender should be 32 bytes"),
+            sender: tx.sender.to_vec().try_into().map_err(|_| {
+                MsgPackError::EncodingError("sender should be 32 byte public key".to_string())
+            })?,
             fee: tx.fee,
             first_valid: tx.first_valid,
             last_valid: tx.last_valid,
             genesis_id: tx.genesis_id,
-            genesis_hash: tx.genesis_hash.map(|b| {
-                b.to_vec()
-                    .try_into()
-                    .expect("genesis_hash should be 32 bytes")
-            }),
+            genesis_hash: tx
+                .genesis_hash
+                .map(|b| {
+                    b.to_vec().try_into().map_err(|_| {
+                        MsgPackError::EncodingError(
+                            "genesis_hash should be 32 byte hash".to_string(),
+                        )
+                    })
+                })
+                .transpose()?,
             note: tx.note.map(|b| b.to_vec()),
             rekey_to: tx
                 .rekey_to
-                .map(|b| b.to_vec().try_into().expect("rekey_to should be 32 bytes")),
+                .map(|b| {
+                    b.to_vec().try_into().map_err(|_| {
+                        MsgPackError::EncodingError(
+                            "rekey_to should be 32 byte public key".to_string(),
+                        )
+                    })
+                })
+                .transpose()?,
             lease: tx
                 .lease
-                .map(|b| b.to_vec().try_into().expect("lease should be 32 bytes")),
+                .map(|b| {
+                    b.to_vec().try_into().map_err(|_| {
+                        MsgPackError::EncodingError("lease should be 32 bytes".to_string())
+                    })
+                })
+                .transpose()?,
             group: tx
                 .group
-                .map(|b| b.to_vec().try_into().expect("group should be 32 bytes")),
-        }
+                .map(|b| {
+                    b.to_vec().try_into().map_err(|_| {
+                        MsgPackError::EncodingError("group should be 32 byte hash".to_string())
+                    })
+                })
+                .transpose()?,
+        })
     }
 }
 
-impl From<PayTransactionFields> for algo_models::PayTransactionFields {
-    fn from(tx: PayTransactionFields) -> Self {
-        Self {
-            header: tx.header.into(),
-            receiver: tx
-                .receiver
-                .to_vec()
-                .try_into()
-                .expect("receiver should be 32 bytes"),
+impl TryFrom<PayTransactionFields> for algo_models::PayTransactionFields {
+    type Error = MsgPackError;
+
+    fn try_from(tx: PayTransactionFields) -> Result<Self, MsgPackError> {
+        Ok(Self {
+            header: tx.header.try_into()?,
+            receiver: tx.receiver.to_vec().try_into().map_err(|_| {
+                MsgPackError::EncodingError("receiver should be 32 byte public key".to_string())
+            })?,
             amount: tx.amount,
-            close_remainder_to: tx.close_remainder_to.map(|b| {
-                b.to_vec()
-                    .try_into()
-                    .expect("close_remainder_to should be 32 bytes")
-            }),
-        }
+            close_remainder_to: tx
+                .close_remainder_to
+                .map(|b| {
+                    b.to_vec().try_into().map_err(|_| {
+                        MsgPackError::EncodingError(
+                            "close remainder to should be 32 byte public key".to_string(),
+                        )
+                    })
+                })
+                .transpose()?,
+        })
     }
 }
 
-impl From<AssetTransferTransactionFields> for algo_models::AssetTransferTransactionFields {
-    fn from(tx: AssetTransferTransactionFields) -> Self {
-        Self {
-            header: tx.header.into(),
+impl TryFrom<AssetTransferTransactionFields> for algo_models::AssetTransferTransactionFields {
+    type Error = MsgPackError;
+
+    fn try_from(tx: AssetTransferTransactionFields) -> Result<Self, MsgPackError> {
+        Ok(Self {
+            header: tx.header.try_into()?,
             asset_id: tx.asset_id,
             amount: tx.amount,
-            receiver: tx
-                .receiver
-                .to_vec()
-                .try_into()
-                .expect("receiver should be 32 bytes"),
-            asset_sender: tx.asset_sender.map(|b| {
-                b.to_vec()
-                    .try_into()
-                    .expect("asset_sender should be 32 bytes")
-            }),
-            close_remainder_to: tx.close_remainder_to.map(|b| {
-                b.to_vec()
-                    .try_into()
-                    .expect("close_remainder_to should be 32 bytes")
-            }),
-        }
+            receiver: tx.receiver.to_vec().try_into().map_err(|_| {
+                MsgPackError::EncodingError("receiver should be 32 byte public key".to_string())
+            })?,
+            asset_sender: tx
+                .asset_sender
+                .map(|b| {
+                    b.to_vec().try_into().map_err(|_| {
+                        MsgPackError::EncodingError(
+                            "close remainder to should be 32 byte public key".to_string(),
+                        )
+                    })
+                })
+                .transpose()?,
+            close_remainder_to: tx
+                .close_remainder_to
+                .map(|b| {
+                    b.to_vec().try_into().map_err(|_| {
+                        MsgPackError::EncodingError(
+                            "close remainder to should be 32 byte public key".to_string(),
+                        )
+                    })
+                })
+                .transpose()?,
+        })
     }
 }
 
@@ -346,7 +383,7 @@ pub fn get_encoded_transaction_type(bytes: &[u8]) -> Result<TransactionType, Msg
 #[cfg_attr(feature = "ffi_wasm", wasm_bindgen(js_name = "encodePayment"))]
 #[cfg_attr(feature = "ffi_uniffi", uniffi::export)]
 pub fn encode_payment(tx: PayTransactionFields) -> Result<Vec<u8>, MsgPackError> {
-    let ctx: algo_models::PayTransactionFields = tx.into();
+    let ctx: algo_models::PayTransactionFields = tx.try_into()?;
     Ok(ctx.encode()?)
 }
 
@@ -360,7 +397,7 @@ pub fn decode_payment(bytes: &[u8]) -> Result<PayTransactionFields, MsgPackError
 #[cfg_attr(feature = "ffi_wasm", wasm_bindgen(js_name = "encodeAssetTransfer"))]
 #[cfg_attr(feature = "ffi_uniffi", uniffi::export)]
 pub fn encode_asset_transfer(tx: AssetTransferTransactionFields) -> Result<Vec<u8>, MsgPackError> {
-    let ctx: algo_models::AssetTransferTransactionFields = tx.into();
+    let ctx: algo_models::AssetTransferTransactionFields = tx.try_into()?;
     Ok(ctx.encode()?)
 }
 


### PR DESCRIPTION
This PR migrates away from a reliance on `ByteBuf` within `algo_models`. The main driver for this change is to make the Rust lib more idiomatic and to provide a fixed-length array where fields must be a specific length. The interfaces exposed by `algo_models_ffi` are the same, but there will now be an error thrown on specific fields when it's not the correct length (i.e. pubkey is not 32 bytes). 

This was largely made possible (or rather, made easy) by ditching `serde_bytes` and using [serde_with::Bytes](https://docs.rs/serde_with/latest/serde_with/struct.Bytes.html) instead