### PR TITLE
ci: remove paths

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -2,22 +2,13 @@ name: Python CI
 
 on:
   push:
-    paths:
-      - crates/algo_models_ffi/**
-      - crates/algo_models/**
-      - packages/python/algo_models/**/*
-      - "!*.md"
     branches:
-      - main
       - master
     tags:
       - "*"
   pull_request:
-    paths:
-      - crates/algo_models_ffi/**
-      - creates/algo_models/**
-      - packages/python/algo_models/**/*
-      - "!*.md"
+    branches:
+      - master
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/swift_ci.yml
+++ b/.github/workflows/swift_ci.yml
@@ -2,28 +2,13 @@ name: Swift CI
 
 on:
   push:
-    paths:
-      - crates/algo_models_ffi/**
-      - crates/algo_models/**
-      - packages/swift/AlgoModels/**
-      - scripts/build/languages/swift.ts
-      - scripts/build/index.ts
-      - "!*.md"
-      - .github/workflows/swift_ci.yml
     branches:
-      - main
       - master
     tags:
       - "*"
   pull_request:
-    paths:
-      - crates/algo_models_ffi/**
-      - crates/algo_models/**
-      - packages/swift/AlgoModels/**
-      - scripts/build/languages/swift.ts
-      - scripts/build/index.ts
-      - "!*.md"
-      - .github/workflows/swift_ci.yml
+    branches:
+      - master
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/typescript_ci.yml
+++ b/.github/workflows/typescript_ci.yml
@@ -2,28 +2,13 @@ name: TypeScript CI
 
 on:
   push:
-    paths:
-      - crates/algo_models_ffi/**
-      - crates/algo_models/**
-      - packages/typescript/algo_models/**
-      - scripts/build/languages/typescript.ts
-      - scripts/build/index.ts
-      - "!*.md"
-      - .github/workflows/typescript_ci.yml
     branches:
-      - main
       - master
     tags:
       - "*"
   pull_request:
-    paths:
-      - crates/algo_models_ffi/**
-      - crates/algo_models/**
-      - packages/typescript/algo_models/**
-      - scripts/build/languages/typescript.ts
-      - scripts/build/index.ts
-      - "!*.md"
-      - .github/workflows/typescript_ci.yml
+    branches:
+      - master
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Removing paths for now because they can be a bit hard to manage. Rather have CI run often rather than not run when it should (for now at least)