### PR TITLE
feat(typescript): define main and module

### DIFF
--- a/packages/typescript/algo_models/package.json
+++ b/packages/typescript/algo_models/package.json
@@ -5,6 +5,8 @@
   "files": [
     "dist/**/*"
   ],
+  "main": "./dist/algo_models.wasm2js.mjs",
+  "module": "./dist/algo_models.wasm2js.mjs",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
During testing of react native not having a main or module defined caused problems. This defines both to be the wasm2js bundle, which is probably the safest bet for any consumer that doesn't support exports. Now confirmed to be working with react native.